### PR TITLE
Require version 1.3.4 of native packager

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 


### PR DESCRIPTION
I needed this because I've got Java 10 installed on my machine and the
bash template code was getting the Java version check wrong (10.0.1 is
not lexically after 1.6)